### PR TITLE
Include Collection objects in collection bags, and allow single collection objects to be bagged without children

### DIFF
--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -314,6 +314,20 @@ function islandora_bagit_admin_settings() {
 function islandora_bagit_create_bag($islandora_object) {
   // First, check to see if the object is a collection, and if it is,
   // reroute to the relevant batch function.
+  foreach ($islandora_object as $ds) {
+    if ($ds->id == 'COLLECTION_POLICY') {
+      if (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'object') {
+        islandora_bagit_create_object_bag_batch($islandora_object);
+      }
+      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'collection') {
+        islandora_bagit_create_collection_bag_batch($islandora_object);
+      }
+      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'no_children') {
+        break;
+      }
+      return array();
+    }
+  }
 
   // Sanitize the PID so it is usable in file paths.
   $pid = str_replace(array(':', '-'), '_', $islandora_object->id);
@@ -353,22 +367,6 @@ function islandora_bagit_create_bag($islandora_object) {
 
   // Create a new bag.
   $bag = new BagIt($bag_output_path, TRUE, TRUE, FALSE, $bag_info);
-
-  foreach ($islandora_object as $ds) {
-    if ($ds->id == 'COLLECTION_POLICY') {
-      if (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'object') {
-        islandora_bagit_create_object_bag_batch($islandora_object);
-      }
-      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'collection') {
-        islandora_bagit_create_collection_bag_batch($islandora_object);
-      }
-      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'no_children') {
-        break;
-      }
-      return array();
-    }
-  }
-
 
   // Iterate through all the object plugins. Each plugin must return the
   // parameters required for addFile() (i.e., a list of file source and
@@ -476,6 +474,7 @@ function islandora_bagit_create_bag($islandora_object) {
  */
 function islandora_bagit_create_object_bag_batch($islandora_object) {
   $objects_to_include = islandora_bagit_get_batch_members($islandora_object);
+  $objects_to_include[] = $islandora_object->id;
   $num_objects = count($objects_to_include);
   $operations = array();
 
@@ -610,6 +609,7 @@ function islandora_bagit_create_collection_bag_batch($islandora_object) {
 
   // Get list of all objects to include in this Bag.
   $objects_to_include = islandora_bagit_get_batch_members($islandora_object);
+  $objects_to_include[] = $islandora_object->id;
   $num_objects = count($objects_to_include);
   $operations = array();
 

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -314,20 +314,6 @@ function islandora_bagit_admin_settings() {
 function islandora_bagit_create_bag($islandora_object) {
   // First, check to see if the object is a collection, and if it is,
   // reroute to the relevant batch function.
-  foreach ($islandora_object as $ds) {
-    if ($ds->id == 'COLLECTION_POLICY') {
-      if (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'object') {
-        islandora_bagit_create_object_bag_batch($islandora_object);
-      }
-      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'collection') {
-        islandora_bagit_create_collection_bag_batch($islandora_object);
-      }
-      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'no_children') {
-        break;
-      }
-      return array();
-    }
-  }
 
   // Sanitize the PID so it is usable in file paths.
   $pid = str_replace(array(':', '-'), '_', $islandora_object->id);
@@ -367,6 +353,22 @@ function islandora_bagit_create_bag($islandora_object) {
 
   // Create a new bag.
   $bag = new BagIt($bag_output_path, TRUE, TRUE, FALSE, $bag_info);
+
+  foreach ($islandora_object as $ds) {
+    if ($ds->id == 'COLLECTION_POLICY') {
+      if (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'object') {
+        islandora_bagit_create_object_bag_batch($islandora_object);
+      }
+      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'collection') {
+        islandora_bagit_create_collection_bag_batch($islandora_object);
+      }
+      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'no_children') {
+        break;
+      }
+      return array();
+    }
+  }
+
 
   // Iterate through all the object plugins. Each plugin must return the
   // parameters required for addFile() (i.e., a list of file source and

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -151,6 +151,7 @@ function islandora_bagit_admin_settings() {
     '#options' => array(
       'object' => t('one Bag per object'),
       'collection' => t('one Bag per collection'),
+      'no_children' => t('the Collection object only; children will not be bagged'),
     ),
     '#description' => t('Choose whether collection-level batches create one Bag per object or one Bag per collection.'),
   );
@@ -318,8 +319,11 @@ function islandora_bagit_create_bag($islandora_object) {
       if (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'object') {
         islandora_bagit_create_object_bag_batch($islandora_object);
       }
-      if (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'collection') {
+      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'collection') {
         islandora_bagit_create_collection_bag_batch($islandora_object);
+      }
+      elseif (variable_get('islandora_bagit_multiple_bag_type', 'object') == 'no_children') {
+        break;
       }
       return array();
     }


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2402, https://jira.duraspace.org/browse/ISLANDORA-1305)

# What does this Pull Request do?

Provides an additional option for creating Collection bags: Collection only, no children. Produces a Bag of collection metadata and other datastreams. Also includes the Collection object in Collection bags.

# What's new?

Now offers the ability to treat a Collection as an object like any other. If the 'no_children' option is selected, when you choose "create bag" for a collection object, you'll get a nice little bag of the Collection's rels-ext, mods, etc.

This is useful when you want a Collection bag for future preservation purposes, and you've got bags of child objects already and don't want to re-bag them.

If creating a collection bag with its child objects, includes the collection object itself as part of the bag.

# How should this be tested?

- Check out this branch
- Choose the new option in the Bagit config
- Create a collection bag; you should get one, without any children attached.
- Change options and create another collection bag, see that collection object is now included in the generated bag

# Interested parties
@mjordan  @Islandora/7-x-1-x-committers
