### PR TITLE
Work on ISLANODRA-2421 - multiple Payload-Oxum tags not allowed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,19 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
+  allow_failures:
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
   - 5.4
   - 5.5
@@ -33,7 +46,6 @@ branches:
   only:
     - /^7.x/
 before_install:
-  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false; fi;
   - cd $HOME
   - git clone -b 7.x git://github.com/Islandora/islandora.git
   - git clone -b 7.x git://github.com/Islandora/islandora_solution_pack_collection.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ branches:
   only:
     - /^7.x/
 before_install:
+  - if [[ $(phpenv version-name) = "5.3.3" ]]; then composer config -g -- disable-tls true && composer config -g -- secure-http false; fi;
   - cd $HOME
   - git clone -b 7.x git://github.com/Islandora/islandora.git
   - git clone -b 7.x git://github.com/Islandora/islandora_solution_pack_collection.git

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -1135,7 +1135,7 @@ function islandora_bagit_get_octetstream_sum($files) {
   $filesize_sum = 0;
   foreach ($files as $file) {
     $file_counter++;
-    $filesize_sum = $filesize_sum + filesize($file);
+    $filesize_sum = $filesize_sum + (int) filesize($file);
   }
   return $filesize_sum . '.' . $file_counter;
 }

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -361,6 +361,8 @@ function islandora_bagit_create_bag($islandora_object) {
   // A list of all the files added to the bag, to show the user and add to
   // the watchdog entries.
   $all_added_files = array();
+  // Needed for islandora_bagit_get_octetstream_sum().
+  $all_added_files_sources = array();
 
   // Get bag-info.txt metadata.
   $bag_info = islandora_bagit_create_baginfo();
@@ -383,13 +385,14 @@ function islandora_bagit_create_bag($islandora_object) {
           foreach ($files_to_add as $file) {
             $bag->addFile($file['source'], $file['dest']);
             $all_added_files[] = $file['dest'];
+            $all_added_files_sources[] = $file['source'];
           }
         }
       }
     }
     // Generate octetstream sum.
     if (variable_get('islandora_bagit_payload_octetstream_sum', 0)) {
-      $sum = islandora_bagit_get_octetstream_sum($files_to_add);
+      $sum = islandora_bagit_get_octetstream_sum($all_added_files_sources);
       $bag->setBagInfoData('Payload-Oxum', $sum);
     }
     $bag->update();
@@ -1122,8 +1125,7 @@ function islandora_bagit_unserialize_bag_object() {
  * level Bags in islandora_bagit_collection_batch_finish_bag().
  *
  * @param array $files
- *   Associative array of file info (with 'source' and 'dest'
- *   keys) returned by a plugins.
+ *   Array of source paths for files added to the Bag.
  *
  * @return string
  *   The Payload-Oxum value.
@@ -1133,7 +1135,7 @@ function islandora_bagit_get_octetstream_sum($files) {
   $filesize_sum = 0;
   foreach ($files as $file) {
     $file_counter++;
-    $filesize_sum = filesize($file['source']) + $filesize_sum;
+    $filesize_sum = $filesize_sum + filesize($file);
   }
   return $filesize_sum . '.' . $file_counter;
 }

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -372,6 +372,7 @@ function islandora_bagit_create_bag($islandora_object) {
   // parameters required for addFile() (i.e., a list of file source and
   // destination paths) or FALSE if it doesn't want to create a file.
   $plugins = variable_get('islandora_bagit_object_plugins', array(''));
+  $files_to_add = array();
   if (count($plugins)) {
     foreach ($plugins as $plugin => $enabled) {
       if ($enabled) {
@@ -379,17 +380,17 @@ function islandora_bagit_create_bag($islandora_object) {
         $plugin_init_function = 'islandora_bagit_' . $plugin . '_init';
         // Process the plugins.
         if ($files_to_add = $plugin_init_function($islandora_object, $tmp_ds_directory)) {
-          // Generate octetstream sum.
-          if (variable_get('islandora_bagit_payload_octetstream_sum', 0)) {
-            $sum = islandora_bagit_get_octetstream_sum($files_to_add);
-            $bag->setBagInfoData('Payload-Oxum', $sum);
-          }
           foreach ($files_to_add as $file) {
             $bag->addFile($file['source'], $file['dest']);
             $all_added_files[] = $file['dest'];
           }
         }
       }
+    }
+    // Generate octetstream sum.
+    if (variable_get('islandora_bagit_payload_octetstream_sum', 0)) {
+      $sum = islandora_bagit_get_octetstream_sum($files_to_add);
+      $bag->setBagInfoData('Payload-Oxum', $sum);
     }
     $bag->update();
   }


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2421

# What does this Pull Request do?

Fixes bug where a Payload-Oxum tag is added to bag-info.txt is added for each enabled plugin. Only one Payload-Oxum tag must be added to bag-info.txt.

# What's new?

The call to the function that generated Payload-Oxum was within the loop that iterated over all enabled plugins. It now follows that loop.

# How should this be tested?

1. Check out this branch.
1. In the Bagit config settings, enable the Payload-Oxum tag.
1. Enable more than on plugin.
1. Generate a Bag for an object.
1. Look inside that Bag's bag-info.txt. There should only be one Payload-Oxum tag.

# Interested parties
@Natkeeran, @MarcusBarnes 
