### PR TITLE
Work on ISLANDORA-2422 - Bagit zip file gets appended rather than replaced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,19 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
+  allow_failures:
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
   - 5.4
   - 5.5

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -408,6 +408,11 @@ function islandora_bagit_create_bag($islandora_object) {
   $serialized_bag_path = variable_get('islandora_bagit_bag_output_dir', '/tmp') .
     DIRECTORY_SEPARATOR . $bag_file_name;
   $compression_type = variable_get('islandora_bagit_compression_type', 'tgz');
+
+  if (file_exists($serialized_bag_path . '.' . $compression_type)) {
+    unlink($serialized_bag_path . '.' . $compression_type);
+  }
+
   $bag->package($serialized_bag_path, $compression_type);
 
   if (variable_get('islandora_bagit_delete_unserialized_bag', 1)) {
@@ -434,6 +439,7 @@ function islandora_bagit_create_bag($islandora_object) {
   }
 
   $serialized_bag_path .= '.' . $compression_type;
+
   if (variable_get('islandora_bagit_show_messages', 1)) {
     drupal_set_message(t("Bag created and saved at %path", array(
       '%path' => $serialized_bag_path,


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2422

# What does this Pull Request do?

Checks to see if a serialized (zipped) Bag file exists before writing a new one with the same name, and if so, removes it first.

# What's new?

Added check to see if the zipped Bag file exists before writing a new one. If it exists, removes it first.

# How should this be tested?

1. Check out this branch.
1. Configure the Bagit module to use the `plugin_object_foxml` and `plugin_object_ds_basic` plugins.
1. Generate a Bag for an object.
1. Reconfigure the Bagit module to not use the `plugin_object_foxml` plugin (i.e., it should only use the `plugin_object_ds_basic` plugin).
1. Regenerate the Bag for the same object.
1. Open the Bag and confirm that the FOXML file is not present.


# Interested parties
@Natkeeran, @MarcusBarnes
