### PR TITLE
Work on ISLANDORA-2438.

### DIFF
--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -447,7 +447,7 @@ function islandora_bagit_create_bag($islandora_object) {
   }
 
   // Allow other modules to fire the post-Bag creation hook.
-  $post_create_data = module_invoke_all('islandora_bagit_post_create', $pid, $serialized_bag_path);
+  $post_create_data = module_invoke_all('islandora_bagit_post_create', $islandora_object->id, $serialized_bag_path);
 
   if (variable_get('islandora_bagit_provide_download_link', 1)) {
     // file_build_uri() needs a relative path.


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2438

# What does this Pull Request do?

Fixes a bug where the wrong value is passed into the invocation of `hook_islandora_bagit_post_create`.

# What's new?

The current invocation passes a normalized PID (i.e., one with the ':' replaced by a '_'. This fix passes the correct, raw PID in instead.

# How should this be tested?

Create a small module that implements this code and enable it:

```php
/**
 * Implements hook_islandora_bagit_post_create().
 *
 * @param string $pid
 *   The PID of the Islandora object that the Bag was just created for.
 *
 * @param string $bag_path
 *  The path to the Bag, relative to the Drupal installation directory.
 */
function mymodule_islandora_bagit_post_create($pid, $bag_path) {
  // Assume devel module is enabled.
  dd($pid);
}
```
1. Create a Bag for an object. 
1. Look at `/rmp/drupal_debug.txt`. It will contain a PID that contains an underscore.
1. Check out this branch and recreate a bag for the same object. The PID that is written to `/tmp/drupal_debug.txt` this time contains a ':'.

# Additional info

* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation?  No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.
* Could this change impact execution of existing code? It fixes a bug in existing code.

# Interested parties
@bondjimbond 
