### PR TITLE
Set Default plugin

### DIFF
--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -214,8 +214,6 @@ function islandora_bagit_admin_settings() {
     )),
     '#description' => t("Object-level plugins. Plugins are fired in their order in this list and all add files to the same Bag. You should choose at least one plugin."),
   );
-  $testvar = variable_get('islandora_bagit_object_plugins');
-  dd($testvar);
   $collection_plugins = islandora_bagit_get_plugins('collection');
   foreach ($collection_plugins as $plugin) {
     $collection_plugin_options[$plugin] = $plugin;

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -209,10 +209,13 @@ function islandora_bagit_admin_settings() {
     '#title' => t('Object plugins'),
     '#type' => 'checkboxes',
     '#options' => $object_plugin_options,
-    '#default_value' => variable_get('islandora_bagit_object_plugins', array('')),
+    '#default_value' => variable_get('islandora_bagit_object_plugins', array(
+      'plugin_object_ds_basic' => 'plugin_object_ds_basic',
+    )),
     '#description' => t("Object-level plugins. Plugins are fired in their order in this list and all add files to the same Bag. You should choose at least one plugin."),
   );
-
+  $testvar = variable_get('islandora_bagit_object_plugins');
+  dd($testvar);
   $collection_plugins = islandora_bagit_get_plugins('collection');
   foreach ($collection_plugins as $plugin) {
     $collection_plugin_options[$plugin] = $plugin;


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2466)

# What does this Pull Request do?

Sets plugin_object_ds_basic as default.

# What's new?

This module requires at least one plugin to be selected in order to run, but does not select any plugins by default. In consequence, clicking "Create Bag" when you haven't configured a plugin generates an empty bag.

This PR is a partial fix: sets plugin_object_ds_basic (which provides all of an object's datastreams) as default, which is the most typical basic use case for a Bag.

# How should this be tested?

* Enable islandora_bagit (uninstall the module and re-enable if you've already been using it)
* Check to see that the plugin_object_ds_basic plugin is selected by default
* Select some others and make sure nothing weird happens

# Additional Notes:

This does not resolve the bug where selecting no plugin still allows the creation of empty bags. And you could deselct the default plugin and not enable any others without protest from the module.

# Interested parties
@mjordan, @Islandora/7-x-1-x-committers
