### PR TITLE
Fail gracefully if the output directory does not already exist

### DIFF
--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -313,6 +313,13 @@ function islandora_bagit_admin_settings() {
  *   a link to 'Download the Bag.'
  */
 function islandora_bagit_create_bag($islandora_object) {
+  $bag_output_dir = variable_get('islandora_bagit_bag_output_dir', '/tmp');
+  if (!file_exists($bag_output_dir)) {
+    drupal_set_message(t('There is no output Bag directory.'), 'warning');
+    watchdog('bagit', 'BagIt Bag not created for !object: output directory missing.',
+      array('!object' => $islandora_object->id));
+    throw new Exception('Missing output bag directory '.$bag_output_dir);
+  }
   // First, check to see if the object is a collection, and if it is,
   // reroute to the relevant batch function.
   foreach ($islandora_object as $ds) {
@@ -349,7 +356,7 @@ function islandora_bagit_create_bag($islandora_object) {
   }
 
   $bag_file_name = variable_get('islandora_bagit_bag_name', 'Bag-') . $pid;
-  $bag_output_path = variable_get('islandora_bagit_bag_output_dir', '/tmp') .
+  $bag_output_path = $bag_output_dir .
     DIRECTORY_SEPARATOR . $bag_file_name;
 
   // Because the BagItPHP library does some things by default if the bag output

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -318,7 +318,7 @@ function islandora_bagit_create_bag($islandora_object) {
     drupal_set_message(t('There is no output Bag directory.'), 'warning');
     watchdog('bagit', 'BagIt Bag not created for !object: output directory missing.',
       array('!object' => $islandora_object->id));
-    throw new Exception('Missing output bag directory '.$bag_output_dir);
+    throw new Exception('Missing output bag directory ' . $bag_output_dir);
   }
   // First, check to see if the object is a collection, and if it is,
   // reroute to the relevant batch function.


### PR DESCRIPTION
**JIRA Ticket**: N/A

# Present a warning if the output directory does not exist when bagging object

I configured the module without also creating the "Output directory for serialized Bags", and was greeted with the following messages on a drush run:
```
mkdir(): No such file or directory bagit.php:611                                                         [warning]
mkdir(): Permission denied bagit.php:617                                                                 [warning]
touch(): Unable to create file /manifest-sha1.txt because Permission denied bagit_manifest.php:113       [warning]
file_put_contents(/bagit.txt): failed to open stream: Permission denied bagit_utils.php:252              [warning]
touch(): Unable to create file /tagmanifest-sha1.txt because Permission denied bagit_manifest.php:113    [warning]
touch(): Unable to create file /bag-info.txt because Permission denied bagit.php:656                     [warning]
mkdir(): Permission denied bagit.php:435                                                                 [warning]
copy(/data/foo.xml): failed to open stream: No such file or directory bagit.php:438                      [warning]
mkdir(): Permission denied bagit.php:435                                                                 [warning]
copy(/data/RELS-EXT.rdf): failed to open stream: No such file or directory bagit.php:438                 [warning]
```

# What's new?
Adds a Drupal messaging and an Exception thrown if the output directory does not exist.

This prevents a slew of impossible operation attempts.

# How should this be tested?

* Configure without a valid output directory
* Run a drush bagging operation

# Additional Notes:
N/A

# Interested parties
@Islandora/7-x-1-x-committers
