### PR TITLE
Add paged datastream plugin

### DIFF
--- a/plugins/plugin_object_ds_paged.inc
+++ b/plugins/plugin_object_ds_paged.inc
@@ -26,7 +26,7 @@ function islandora_bagit_plugin_object_ds_paged_init($islandora_object, $tmp_ds_
   $supported_cmodels = array(
     'islandora:manuscriptCModel',
     'islandora:bookCModel',
-    'islandora:newspaperIssueCModel'
+    'islandora:newspaperIssueCModel',
   );
   $found_cmodels = array_intersect($islandora_object->models, $supported_cmodels);
   if (empty($found_cmodels)) {

--- a/plugins/plugin_object_ds_paged.inc
+++ b/plugins/plugin_object_ds_paged.inc
@@ -24,7 +24,8 @@
 function islandora_bagit_plugin_object_ds_paged_init($islandora_object, $tmp_ds_directory) {
   // What Content Models have pages?
   $supported_cmodels = array('islandora:manuscriptCModel','islandora:bookCModel','islandora:newspaperIssueCModel');
-  if (empty(array_intersect($islandora_object->models, $supported_cmodels))) {
+  $found_cmodels = array_intersect($islandora_object->models, $supported_cmodels);
+  if (empty($found_cmodels)) {
     return FALSE;
   }
   if (module_load_include('inc', 'islandora_paged_content', 'includes/utilities') === FALSE) {
@@ -32,9 +33,15 @@ function islandora_bagit_plugin_object_ds_paged_init($islandora_object, $tmp_ds_
   }
   $files_to_add = array();
   $pages = islandora_paged_content_get_pages($islandora_object);
+  $page_count = 0;
   foreach ($pages as $page) {
     $page_object = islandora_object_load($page['pid']);
-    $ds_files = islandora_bagit_retrieve_datastreams($page_object, $tmp_ds_directory);
+    $page_count++;
+    $tmp_ds_subdir = $tmp_ds_directory . DIRECTORY_SEPARATOR . 'p' . $page_count;
+    if (!file_exists($tmp_ds_subdir)) {
+      mkdir($tmp_ds_subdir, 0777, TRUE);
+    }
+    $ds_files = islandora_bagit_retrieve_datastreams($page_object, $tmp_ds_subdir);
 
     // Add file source and dest paths for each datastream to the $files_to_add
     // array. $files_to_add['dest'] must be relative to the Bag's data

--- a/plugins/plugin_object_ds_paged.inc
+++ b/plugins/plugin_object_ds_paged.inc
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Plugin for the Islandora BagIt Drupal module.
+ *
+ * Registers all the datastreams in pages of an Islandora object so they are
+ * copied into the 'data' directory.
+ */
+
+/**
+ * Returns an array of source and destination file paths.
+ *
+ * @param object $islandora_object
+ *   The Islandora object to create a Bag for.
+ *
+ * @param string $tmp_ds_directory
+ *   The temporary directory where the datastream files have been downloaded.
+ *
+ * @return array|bool
+ *   An array of source and destination file paths, or FALSE
+ *   if no datastream files are present.
+ */
+function islandora_bagit_plugin_object_ds_paged_init($islandora_object, $tmp_ds_directory) {
+  if (module_load_include('inc', 'islandora_paged_content', 'includes/utilities') === FALSE) {
+    return FALSE;
+  }
+  $files_to_add = array();
+  $pages = islandora_paged_content_get_pages($islandora_object);
+  foreach ($pages as $page) {
+    $page_object = islandora_object_load($page['pid']);
+    $ds_files = islandora_bagit_retrieve_datastreams($page_object, $tmp_ds_directory);
+
+    // Add file source and dest paths for each datastream to the $files_to_add
+    // array. $files_to_add['dest'] must be relative to the Bag's data
+    // subdirectory.
+    foreach ($ds_files as $ds_filename) {
+      // Add each file in the directory to $files_to_add.
+      $source_file_to_add = $ds_filename;
+      if (file_exists($source_file_to_add) && is_file($source_file_to_add)) {
+        $files_to_add[] = array(
+          'source' => $source_file_to_add,
+          // Each page becomes a subdirectory in the Bag's 'data' directory.
+          'dest' => str_replace(array(':', '-'), '_', $page['pid']) . DIRECTORY_SEPARATOR . basename($ds_filename),
+        );
+      }
+    }
+  }
+
+  if (count($files_to_add)) {
+    return $files_to_add;
+  }
+  else {
+    return FALSE;
+  }
+}

--- a/plugins/plugin_object_ds_paged.inc
+++ b/plugins/plugin_object_ds_paged.inc
@@ -22,6 +22,11 @@
  *   if no datastream files are present.
  */
 function islandora_bagit_plugin_object_ds_paged_init($islandora_object, $tmp_ds_directory) {
+  // What Content Models have pages?
+  $supported_cmodels = array('islandora:manuscriptCModel','islandora:bookCModel','islandora:newspaperIssueCModel');
+  if (empty(array_intersect($islandora_object->models, $supported_cmodels))) {
+    return FALSE;
+  }
   if (module_load_include('inc', 'islandora_paged_content', 'includes/utilities') === FALSE) {
     return FALSE;
   }

--- a/plugins/plugin_object_ds_paged.inc
+++ b/plugins/plugin_object_ds_paged.inc
@@ -23,7 +23,11 @@
  */
 function islandora_bagit_plugin_object_ds_paged_init($islandora_object, $tmp_ds_directory) {
   // What Content Models have pages?
-  $supported_cmodels = array('islandora:manuscriptCModel','islandora:bookCModel','islandora:newspaperIssueCModel');
+  $supported_cmodels = array(
+    'islandora:manuscriptCModel',
+    'islandora:bookCModel',
+    'islandora:newspaperIssueCModel'
+  );
   $found_cmodels = array_intersect($islandora_object->models, $supported_cmodels);
   if (empty($found_cmodels)) {
     return FALSE;


### PR DESCRIPTION
**JIRA Ticket**: N/A

# What does this Pull Request do?

Adds a plugin which allows for the bagging of pages of paged objects with the parent object's bag.

# What's new?
New plugin `plugin_object_ds_paged` which, for select content types, will leverage `islandora_paged_content` to find and add the datastreams for pages within the parent object's bag.

# How should this be tested?

A description of what steps someone could take to:
* Enable plugin `plugin_object_ds_paged` in the module's settings
* Bag a object without pages (e.g. findingAidCModel, largeImageCModel, etc), and no change occurs
* Bag an object with pages (e.g. manuscriptCModel, bookCModel, newspaperIssueCModel), and the datastreams of the paged objects will be added to the bag's data, under folders named by the page object.

# Additional Notes:

* This plugin depends on `islandora_paged_content`, but should fail gracefully if not present.
* Directory and datastream naming is modeled off of `plugin_object_ds_basic`

# Interested parties
@Islandora/7-x-1-x-committers
