### PR TITLE
add plugin to export compound children as data folders

### DIFF
--- a/plugins/plugin_object_ds_compound.inc
+++ b/plugins/plugin_object_ds_compound.inc
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @file
+ * Plugin for the Islandora BagIt Drupal module.
+ *
+ * Registers all the datastreams  the immediate children of an Islandora 
+ * compound object so they are copied into the 'data' directory.
+ */
+
+/**
+ * Returns an array of source and destination file paths.
+ *
+ * @param object $islandora_object
+ *   The Islandora object to create a Bag for.
+ *
+ * @param string $tmp_ds_directory
+ *   The temporary directory where the datastream files have been downloaded.
+ *
+ * @return array|bool
+ *   An array of source and destination file paths, or FALSE
+ *   if no datastream files are present.
+ */
+function islandora_bagit_plugin_object_ds_compound_init($islandora_object, $tmp_ds_directory) {
+  // What Content Models are compound?
+  $supported_cmodels = array('islandora:compoundCModel');
+  $found_cmodels = array_intersect($islandora_object->models, $supported_cmodels);
+  if (empty($found_cmodels)) {
+    return FALSE;
+  }
+  if (module_load_include('module', 'islandora_compound_object', 'islandora_compound_object') === FALSE) {
+    return FALSE;
+  }
+  $files_to_add = array();
+  $children = islandora_compound_object_get_parts($islandora_object->id);
+  $children_count = 0;
+  foreach ($children as $child_id) {
+    $child_object = islandora_object_load($child_id);
+    $children_count++;
+    $tmp_ds_subdir = $tmp_ds_directory . DIRECTORY_SEPARATOR . 'c' . $children_count;
+    if (!file_exists($tmp_ds_subdir)) {
+      mkdir($tmp_ds_subdir, 0777, TRUE);
+    }
+    $ds_files = islandora_bagit_retrieve_datastreams($child_object, $tmp_ds_subdir);
+
+    // Add file source and dest paths for each datastream to the $files_to_add
+    // array. $files_to_add['dest'] must be relative to the Bag's data
+    // subdirectory.
+    foreach ($ds_files as $ds_filename) {
+      // Add each file in the directory to $files_to_add.
+      $source_file_to_add = $ds_filename;
+      if (file_exists($source_file_to_add) && is_file($source_file_to_add)) {
+        $files_to_add[] = array(
+          'source' => $source_file_to_add,
+          // Each page becomes a subdirectory in the Bag's 'data' directory.
+          'dest' => str_replace(array(':', '-'), '_', $child_id) . DIRECTORY_SEPARATOR . basename($ds_filename),
+        );
+      }
+    }
+  }
+
+  if (count($files_to_add)) {
+    return $files_to_add;
+  }
+  else {
+    return FALSE;
+  }
+}


### PR DESCRIPTION
**JIRA Ticket**: n/a

* Other Relevant Links: based on strategy of https://github.com/Islandora/islandora_bagit/pull/64

# What does this Pull Request do?

Adds a plugin which allows for the bagging the children of compound objects with the parent object's bag.

# What's new?
New plugin `plugin_object_ds_compound` which, for `islandora:compoundCModel`, will leverage the module `islandora_compound_object` to find and add the datastreams for pages within the parent object's bag.

# How should this be tested?

* Enable plugin `plugin_object_ds_compound` in the module's settings
* Bag an object which does not have the compound model (e.g. `findingAidCModel`, `largeImageCModel`, etc), and no change occurs
* Bag a compound object with children, and the datastreams of the child objects will be added to the bag's data, under folders named by the child object identifier.

# Additional Notes:

* This plugin depends on `islandora_compound_object`, but should fail gracefully if not present.
* Directory and datastream naming is modeled off of `plugin_object_ds_basic`

# Interested parties
Probably no one, just documenting our change.
