### PR TITLE
add option to resume incomplete exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Bags can be created for individual Islandora objects or for all objects in a giv
 
 where UID is the user ID or user name of the fedoraAdmin user (or equivalent), 'object' or 'collection' indicates whether you want to create a Bag for a single object or a Bag for every member of a collection, and PID is the PID of the Islandora object or collection.
 
+By default, the `create-islandora-bag` command will overwrite existing bags with the same name.  An option `--resume` is available which will instead accept the existing bags as-is, and resume processing with the next incomplete bag.
+
 ### Permissions and security
 
 This module is intended for users who have a fairly high level of permissions on a Drupal site. Because the goal is to package up all or some of the datastreams in an Islandora object, users who can create and download Bags should have access to those datastreams. However, the module does check the current users' access to a datastream before adding it to the Bag.

--- a/islandora_bagit.drush.inc
+++ b/islandora_bagit.drush.inc
@@ -42,6 +42,11 @@ function islandora_bagit_drush_command() {
       'Standard example (for collection)' => 'drush --user=fedoraAdmin create-islandora-bag collection islandora:sp_basic_image_collection',
       'Alias example' => 'drush --user=fedoraAdmin cib object islandora:190',
     ),
+    'options' => array(
+      'resume' => array(
+        'description' => 'Resume a prior incomplete operation, retaining completed content.',
+      ),
+    ),
     'aliases' => array('cib'),
     'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_LOGIN,
   );
@@ -89,7 +94,8 @@ function drush_islandora_bagit_create_islandora_bag($type = 'object', $pid = NUL
   foreach ($objects_to_bag as $object_to_bag_pid) {
     try {
       $islandora_object = islandora_object_load($object_to_bag_pid);
-      islandora_bagit_create_bag($islandora_object);
+      $resume = (bool) drush_get_option('resume');
+      islandora_bagit_create_bag($islandora_object, $resume);
     }
     catch (Exception $e) {
       drush_print("Sorry, Islandora cannot create the Bag: " . $e->getMessage());

--- a/islandora_bagit.module
+++ b/islandora_bagit.module
@@ -307,12 +307,14 @@ function islandora_bagit_admin_settings() {
  *
  * @param object $islandora_object
  *   The Islandora object to create a Bag for.
+ * @param boolean $resume
+ *   Whether to resume a prior failed process, skipping the delete for already serialized bags
  *
  * @return string|array
  *   Either an empty array, a blank string, or a string containing
  *   a link to 'Download the Bag.'
  */
-function islandora_bagit_create_bag($islandora_object) {
+function islandora_bagit_create_bag($islandora_object, $resume = false) {
   // First, check to see if the object is a collection, and if it is,
   // reroute to the relevant batch function.
   foreach ($islandora_object as $ds) {
@@ -351,6 +353,18 @@ function islandora_bagit_create_bag($islandora_object) {
   $bag_file_name = variable_get('islandora_bagit_bag_name', 'Bag-') . $pid;
   $bag_output_path = variable_get('islandora_bagit_bag_output_dir', '/tmp') .
     DIRECTORY_SEPARATOR . $bag_file_name;
+
+  $serialized_bag_path = variable_get('islandora_bagit_bag_output_dir', '/tmp') .
+    DIRECTORY_SEPARATOR . $bag_file_name;
+  $compression_type = variable_get('islandora_bagit_compression_type', 'tgz');
+  if ($resume && file_exists($serialized_bag_path . '.' . $compression_type)) {
+    if (variable_get('islandora_bagit_show_messages', 1)) {
+      drupal_set_message(t("Skipping existing Bag at %path", array(
+        '%path' => $serialized_bag_path,
+        )));
+    }
+    return array();
+  }
 
   // Because the BagItPHP library does some things by default if the bag output
   // directory already exists (like read the fetch.txt file), we always need to
@@ -410,10 +424,6 @@ function islandora_bagit_create_bag($islandora_object) {
   drupal_alter('islandora_bagit', $bag, $islandora_object);
 
   // Write out the serialized (i.e., compressed) Bag.
-  $serialized_bag_path = variable_get('islandora_bagit_bag_output_dir', '/tmp') .
-    DIRECTORY_SEPARATOR . $bag_file_name;
-  $compression_type = variable_get('islandora_bagit_compression_type', 'tgz');
-
   if (file_exists($serialized_bag_path . '.' . $compression_type)) {
     unlink($serialized_bag_path . '.' . $compression_type);
   }


### PR DESCRIPTION
**JIRA Ticket**: n/a

# What does this Pull Request do?

By default, the `create-islandora-bag` command will overwrite existing bags with the same name. An option `--resume` is available which will instead accept the existing bags as-is, and resume processing with the next incomplete bag.

# What's new?
Drush option `--resume` examines existing bags, and if present emits a message before proceeding to the next bag.

# How should this be tested?

* Cancel a collection export of multiple objects mid-way through.
* Re-run the command with the `--resume` option, and observe that completed bags are untouched, and missing bags are added.
* Re-run the command without the `--resume` option, and observe that all bags are re-created.

# Additional Notes:
This does move a late set of the `$serialized_bag_path` and `$compression_type` to an early statement for the sake of checking for the existence of the serialized output.

# Interested parties
Probably no one, just documenting our change.
